### PR TITLE
Fixing undefined reference for template function

### DIFF
--- a/src/graph_t.h
+++ b/src/graph_t.h
@@ -139,7 +139,10 @@ struct subgraph_t {
     void        find_sssp(node_id_t s, vector<int>& out_vec);
     
     template <typename T>
-    void        i_fill_map(vector<T>& vec, T val);
+    void        i_fill_map(vector<T>& vec, T val){
+        vec.resize(nodes_vec.size());
+        fill(vec.begin(), vec.end(), val);
+    }
     
     void        find_pruning_counts_exp(node_id_t src,
                                         node_id_t dst,

--- a/src/subgraph_t.cc
+++ b/src/subgraph_t.cc
@@ -24,12 +24,6 @@ vector<node_id_t>& subgraph_t::get_nbrs(node_id_t id)
     return nodes_vec[id];
 }
 
-template <typename T>
-void subgraph_t::i_fill_map(vector<T>& vec, T val)
-{
-    vec.resize(nodes_vec.size());
-    fill(vec.begin(), vec.end(), val);
-}
 
 void subgraph_t::init_maps()
 {


### PR DESCRIPTION
In current gcc compiler I get error with template function not implemented in header file, as explained here: https://stackoverflow.com/questions/8752837/undefined-reference-to-template-class-constructor